### PR TITLE
Run another instance of the existing ghost-racer container.

### DIFF
--- a/docker_run.bash
+++ b/docker_run.bash
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+RACER_DOCKER_CONTAINER_ID=$(sudo docker ps -aqf "name=ghost-racer")
+
+if [ ! -z "$RACER_DOCKER_CONTAINER_ID" ];then
+    # exec existing container
+    echo "Opening existing ghost-racer's container [$RACER_DOCKER_CONTAINER_ID]"
+    sudo docker exec -it $RACER_DOCKER_CONTAINER_ID /bin/bash
+    exit 0
+fi
+
 ghost_racer_root_dir=$1
 docker_ghost_racer_root_dir=/home/ghost/ghost-racer
 
@@ -21,4 +30,5 @@ docker run -it --rm \
     -p 11311:11311 \
     -v /tmp/.X11-unix/:/tmp/.X11-unix/ \
     -v $ghost_racer_root_dir:$docker_ghost_racer_root_dir \
+    --name "ghost-racer" \
     jakubtomczak/ghost-racer


### PR DESCRIPTION
For now, it is not possible to expose all ports needed for a successful communication between nodes running in a container and on the host. This change just opens the existing container to allow quicker launch of another node. To open the container it is enough to type `sudo ./docker_run.sh` and the container opens.